### PR TITLE
Update addon-developer-support

### DIFF
--- a/src/api/LegacyPrefs/README.md
+++ b/src/api/LegacyPrefs/README.md
@@ -4,31 +4,46 @@ Use this API to access Thunderbird's system preferences or to migrate your own p
 
 ## Usage
 
-### API Functions
+Add the [LegacyPrefs API](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs) to your add-on. Your `manifest.json` needs an entry like this:
+
+```
+  "experiment_apis": {
+    "LegacyPrefs": {
+      "schema": "api/LegacyPrefs/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["LegacyPrefs"]],
+        "script": "api/LegacyPrefs/implementation.js"
+      }
+    }
+  },
+```
+
+## API Functions
 
 This API provides the following functions:
 
-#### async getPref(aName, [aFallback])
+### async getPref(aName, [aFallback])
 
 Returns the value for the ``aName`` preference. If it is not defined or has no default value assigned, ``aFallback`` will be returned (which defaults to ``null``).
 
-#### async getUserPref(aName)
+### async getUserPref(aName)
 
 Returns the user defined value for the ``aName`` preference. This will ignore any defined default value and will only return an explicitly set value, which differs from the default. Otherwise it will return ``null``.
 
-#### clearUserPref(aName)
+### clearUserPref(aName)
 
 Clears the user defined value for preference ``aName``. Subsequent calls to ``getUserPref(aName)`` will return ``null``.
 
-#### async setPref(aName, aValue)
+### async setPref(aName, aValue)
 
 Set the ``aName`` preference to the given value. Will return false and log an error to the console, if the type of ``aValue`` does not match the type of the preference.
 
-### API Events
+## API Events
 
 This API provides the following events:
 
-#### onChanged.addListener(listener, branch)
+### onChanged.addListener(listener, branch)
 
 Register a listener which is notified each time a value in the specified branch is changed. The listener returns the name and the new value of the changed preference.
 

--- a/src/api/LegacyPrefs/implementation.js
+++ b/src/api/LegacyPrefs/implementation.js
@@ -2,25 +2,31 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
- * Version: 1.8
- * reworked onChanged event to allow registering multiple branches
+ * Version 1.10
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
  *
- * Version: 1.7
- * add onChanged event
+ * Version 1.9
+ * - fixed fallback issue reported by Axel Grude
  *
- * Version: 1.6
- * add setDefaultPref()
+ * Version 1.8
+ * - reworked onChanged event to allow registering multiple branches
  *
- * Version: 1.5
- * replace set/getCharPref by set/getStringPref to fix encoding issue
+ * Version 1.7
+ * - add onChanged event
  *
- * Version: 1.4
+ * Version 1.6
+ * - add setDefaultPref()
+ *
+ * Version 1.5
+ * - replace set/getCharPref by set/getStringPref to fix encoding issue
+ *
+ * Version 1.4
  * - setPref() function returns true if the value could be set, otherwise false
  *
- * Version: 1.3
+ * Version 1.3
  * - add setPref() function
  *
- * Version: 1.2
+ * Version 1.2
  * - add getPref() function
  *
  * Author: John Bieling (john@thunderbird.net)
@@ -36,9 +42,11 @@ var { ExtensionCommon } = ChromeUtils.import(
 var { ExtensionUtils } = ChromeUtils.import(
   "resource://gre/modules/ExtensionUtils.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 var { ExtensionError } = ExtensionUtils;
+
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+
 
 var LegacyPrefs = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {

--- a/src/api/LegacyPrefs/schema.json
+++ b/src/api/LegacyPrefs/schema.json
@@ -54,7 +54,7 @@
           },
           {
             "name": "aFallback",
-            "type": "string",
+            "type": "any",
             "description": "Value to be returned, if the requested preference does not exist.",
             "optional": true,
             "default": null


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . The latest addon-developer-support source reflects the change.