### PR TITLE
Add support for TB115 and TB128

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/api/header-columns-api"]
-	path = src/api/header-columns-api
-	url = https://github.com/peterfab9845/header-columns-api

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ The new column can be selected as soon as the addon has been installed, and all 
 However, there will be no information for existing messages unless the database is rebuilt for the desired folders (Folder Properties > Repair Folder).
 Note that rebuilding a folder will reset its column layout and sort order.
 
-## Cloning
-Note that this repo uses git submodules, so it needs to be cloned using the `--recurse-submodules` option. If this is skipped, then `git submodule update --init` can be used after the fact.
-
 ## Credits
-This addon uses the [HeaderColumns](https://github.com/peterfab9845/header-columns-api), [LegacyPrefs](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs), and [ex_runtime](https://github.com/rsjtdrjgfuzkfg/thunderbird-experiments/tree/master/experiments/runtime) experiment APIs.
+This addon uses the [LegacyPrefs](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs), and [ex_runtime](https://github.com/rsjtdrjgfuzkfg/thunderbird-experiments/tree/master/experiments/runtime) experiment APIs.
 

--- a/src/api/LegacyPrefs/README.md
+++ b/src/api/LegacyPrefs/README.md
@@ -4,31 +4,46 @@ Use this API to access Thunderbird's system preferences or to migrate your own p
 
 ## Usage
 
-### API Functions
+Add the [LegacyPrefs API](https://github.com/thunderbird/addon-developer-support/tree/master/auxiliary-apis/LegacyPrefs) to your add-on. Your `manifest.json` needs an entry like this:
+
+```
+  "experiment_apis": {
+    "LegacyPrefs": {
+      "schema": "api/LegacyPrefs/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["LegacyPrefs"]],
+        "script": "api/LegacyPrefs/implementation.js"
+      }
+    }
+  },
+```
+
+## API Functions
 
 This API provides the following functions:
 
-#### async getPref(aName, [aFallback])
+### async getPref(aName, [aFallback])
 
 Returns the value for the ``aName`` preference. If it is not defined or has no default value assigned, ``aFallback`` will be returned (which defaults to ``null``).
 
-#### async getUserPref(aName)
+### async getUserPref(aName)
 
 Returns the user defined value for the ``aName`` preference. This will ignore any defined default value and will only return an explicitly set value, which differs from the default. Otherwise it will return ``null``.
 
-#### clearUserPref(aName)
+### clearUserPref(aName)
 
 Clears the user defined value for preference ``aName``. Subsequent calls to ``getUserPref(aName)`` will return ``null``.
 
-#### async setPref(aName, aValue)
+### async setPref(aName, aValue)
 
 Set the ``aName`` preference to the given value. Will return false and log an error to the console, if the type of ``aValue`` does not match the type of the preference.
 
-### API Events
+## API Events
 
 This API provides the following events:
 
-#### onChanged.addListener(listener, branch)
+### onChanged.addListener(listener, branch)
 
 Register a listener which is notified each time a value in the specified branch is changed. The listener returns the name and the new value of the changed preference.
 
@@ -42,4 +57,4 @@ browser.LegacyPrefs.onChanged.addListener(async (name, value) => {
 
 ---
 
-A detailed example using the LegacyPref API to migrate add-on preferences to the local storage can be found in [/scripts/preferences/](https://github.com/thundernest/addon-developer-support/tree/master/scripts/preferences).
+A detailed example using the LegacyPref API to migrate add-on preferences to the local storage can be found in [/scripts/preferences/](https://github.com/thunderbird/addon-developer-support/tree/master/scripts/preferences).

--- a/src/api/LegacyPrefs/implementation.js
+++ b/src/api/LegacyPrefs/implementation.js
@@ -1,26 +1,36 @@
 /*
  * This file is provided by the addon-developer-support repository at
- * https://github.com/thundernest/addon-developer-support
+ * https://github.com/thunderbird/addon-developer-support
  *
- * Version: 1.8
- * reworked onChanged event to allow registering multiple branches
+ * Version 1.11
+ * - adjusted to TB128 (no longer loading Services and ExtensionCommon)
+ * - use ChromeUtils.importESModule()
+ * 
+ * Version 1.10
+ * - adjusted to Thunderbird 115 (Services is now in globalThis)
  *
- * Version: 1.7
- * add onChanged event
+ * Version 1.9
+ * - fixed fallback issue reported by Axel Grude
  *
- * Version: 1.6
- * add setDefaultPref()
+ * Version 1.8
+ * - reworked onChanged event to allow registering multiple branches
  *
- * Version: 1.5
- * replace set/getCharPref by set/getStringPref to fix encoding issue
+ * Version 1.7
+ * - add onChanged event
  *
- * Version: 1.4
+ * Version 1.6
+ * - add setDefaultPref()
+ *
+ * Version 1.5
+ * - replace set/getCharPref by set/getStringPref to fix encoding issue
+ *
+ * Version 1.4
  * - setPref() function returns true if the value could be set, otherwise false
  *
- * Version: 1.3
+ * Version 1.3
  * - add setPref() function
  *
- * Version: 1.2
+ * Version 1.2
  * - add getPref() function
  *
  * Author: John Bieling (john@thunderbird.net)
@@ -30,14 +40,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { ExtensionCommon } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionCommon.jsm"
-);
-var { ExtensionUtils } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionUtils.jsm"
-);
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+/* global Services, ExtensionCommon */
 
+"use strict";
+
+var { ExtensionUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionUtils.sys.mjs"
+);
 var { ExtensionError } = ExtensionUtils;
 
 var LegacyPrefs = class extends ExtensionCommon.ExtensionAPI {

--- a/src/api/LegacyPrefs/schema.json
+++ b/src/api/LegacyPrefs/schema.json
@@ -54,7 +54,7 @@
           },
           {
             "name": "aFallback",
-            "type": "string",
+            "type": "any",
             "description": "Value to be returned, if the requested preference does not exist.",
             "optional": true,
             "default": null

--- a/src/api/OriginalToColumn/implementation.js
+++ b/src/api/OriginalToColumn/implementation.js
@@ -1,0 +1,77 @@
+"use strict";
+
+// Avoid creating variables in global scope. Put our object in the outer scope
+// via the function argument instead.
+(function (exports) {
+
+  function importThreadPaneColumnsModule() {
+    try {
+      // TB115
+      return ChromeUtils.importESModule("chrome://messenger/content/thread-pane-columns.mjs");
+    } catch (err) {
+      // TB128
+      return ChromeUtils.importESModule("chrome://messenger/content/ThreadPaneColumns.mjs");
+    }
+  }
+  
+  var { ThreadPaneColumns } = importThreadPaneColumnsModule();
+
+  function getXOriginalHeaderValue(hdr) {
+    // The desired header must be stored in the message database, which is
+    // controlled by mailnews.customDBHeaders preference.
+    // getStringProperty returns "" if nothing is found.
+    return hdr.getStringProperty("x-original-to");
+  }
+
+  var OriginalToColumn = class extends ExtensionAPI {
+    /**
+     * Called when the extension is disabled, removed, reloaded, or Thunderbird closes.
+     * @param {boolean} isAppShutdown
+     */
+    onShutdown(isAppShutdown) {
+      if (isAppShutdown) return
+      Services.obs.notifyObservers(null, 'startupcache-invalidate')
+    }
+  
+    /**
+     *
+     * @param {*} context
+     * @returns
+     */
+    getAPI(context) {
+      context.callOnClose(this)
+      return {
+        OriginalToColumn: {
+          /**
+           * @param {string} id - the id of the custom column
+           * @param {string} name  - the name of the custom column
+           * @param {string} tooltip - currently unsupported
+           */
+          async addColumn(id, name, tooltip) {
+            ThreadPaneColumns.addCustomColumn(id, {
+              name: name,
+              hidden: true,
+              icon: false,
+              resizable: true,
+              sortable: true,
+              textCallback: getXOriginalHeaderValue,
+            });
+          },
+  
+          /**
+           * @param {string} id - the id of the custom column
+           */
+          async removeColumn(id) {
+            ThreadPaneColumns.removeCustomColumn(id);
+          }
+        }
+      }
+    }
+  
+    close() {
+      ThreadPaneColumns.removeCustomColumn("spam-score-icon");
+    }
+  }
+
+  exports.OriginalToColumn = OriginalToColumn;
+})(this);

--- a/src/api/OriginalToColumn/implementation.js
+++ b/src/api/OriginalToColumn/implementation.js
@@ -43,12 +43,11 @@
       return {
         OriginalToColumn: {
           /**
-           * @param {string} id - the id of the custom column
            * @param {string} name  - the name of the custom column
            * @param {string} tooltip - currently unsupported
            */
-          async addColumn(id, name, tooltip) {
-            ThreadPaneColumns.addCustomColumn(id, {
+          async addColumn(name, tooltip) {
+            ThreadPaneColumns.addCustomColumn("originalToColumn", {
               name: name,
               hidden: true,
               icon: false,
@@ -58,18 +57,15 @@
             });
           },
   
-          /**
-           * @param {string} id - the id of the custom column
-           */
-          async removeColumn(id) {
-            ThreadPaneColumns.removeCustomColumn(id);
+          async removeColumn() {
+            ThreadPaneColumns.removeCustomColumn("originalToColumn");
           }
         }
       }
     }
   
     close() {
-      ThreadPaneColumns.removeCustomColumn("spam-score-icon");
+      ThreadPaneColumns.removeCustomColumn("originalToColumn");
     }
   }
 

--- a/src/api/OriginalToColumn/schema.json
+++ b/src/api/OriginalToColumn/schema.json
@@ -1,0 +1,43 @@
+[
+  {
+    "namespace": "OriginalToColumn",
+    "functions": [
+      {
+        "name": "addColumn",
+        "type": "function",
+        "description": "Add a custom column",
+        "async": false,
+        "parameters": [
+          {
+            "name": "id",
+            "type": "string",
+            "description": "The ID for the column element. Must be unique."
+          },
+          {
+            "name": "label",
+            "type": "string",
+            "description": "The label for the column header."
+          },
+          {
+            "name": "tooltip",
+            "type": "string",
+            "description": "The on-hover tooltip for the column header."
+          }
+        ]
+      },
+      {
+        "name": "removeColumn",
+        "type": "function",
+        "description": "Remove a custom column",
+        "async": false,
+        "parameters": [
+          {
+            "name": "id",
+            "type": "string",
+            "description": "The ID of the column element to unregister."
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/api/OriginalToColumn/schema.json
+++ b/src/api/OriginalToColumn/schema.json
@@ -9,11 +9,6 @@
         "async": false,
         "parameters": [
           {
-            "name": "id",
-            "type": "string",
-            "description": "The ID for the column element. Must be unique."
-          },
-          {
             "name": "label",
             "type": "string",
             "description": "The label for the column header."
@@ -31,11 +26,6 @@
         "description": "Remove a custom column",
         "async": false,
         "parameters": [
-          {
-            "name": "id",
-            "type": "string",
-            "description": "The ID of the column element to unregister."
-          }
         ]
       }
     ]

--- a/src/background.js
+++ b/src/background.js
@@ -7,7 +7,6 @@ await addCustomDBHeader("X-Original-To");
 await messenger.ex_runtime.onDisable.addListener(removeCustomDBHeader.bind(null, "X-Original-To"));
 
 await messenger.OriginalToColumn.addColumn(
-  "originalToColumn",
   "X-Original-To",
   "Sort by X-Original-To header"
 );

--- a/src/background.js
+++ b/src/background.js
@@ -1,33 +1,13 @@
 "use strict";
 
-async function init() {
-  // set up customDBHeaders
-  await addCustomDBHeader("X-Original-To");
-  messenger.ex_runtime.onDisable.addListener(removeCustomDBHeader.bind(null, "X-Original-To"));
+import { addCustomDBHeader, removeCustomDBHeader } from "./customDBHeaders.js";
 
-  // add the column
-  let originalToTree = {
-    "nodeType": "header",
-    "headerName": "X-Original-To"
-  };
-  messenger.HeaderColumns.registerColumn("originalToColumn", "X-Original-To", "Sort by X-Original-To header", originalToTree, false);
-}
-init();
+// Set up customDBHeaders.
+await addCustomDBHeader("X-Original-To");
+await messenger.ex_runtime.onDisable.addListener(removeCustomDBHeader.bind(null, "X-Original-To"));
 
-// Add a header to customDBHeaders if it's missing
-async function addCustomDBHeader(headerName) {
-  let customDBHeaders = await messenger.LegacyPrefs.getPref("mailnews.customDBHeaders", "");
-  if (!customDBHeaders.toLowerCase().includes(headerName.toLowerCase())) {
-    customDBHeaders += " " + headerName;
-    await messenger.LegacyPrefs.setPref("mailnews.customDBHeaders", customDBHeaders);
-  }
-}
-
-// Remove a header from customDBHeaders if it's present
-async function removeCustomDBHeader(headerName) {
-  let customDBHeaders = await messenger.LegacyPrefs.getPref("mailnews.customDBHeaders", "");
-  let regex = new RegExp(` *${headerName}`, "i");
-  customDBHeaders = customDBHeaders.replace(regex, "");
-  await messenger.LegacyPrefs.setPref("mailnews.customDBHeaders", customDBHeaders);
-}
-
+await messenger.OriginalToColumn.addColumn(
+  "originalToColumn",
+  "X-Original-To",
+  "Sort by X-Original-To header"
+);

--- a/src/customDBHeaders.js
+++ b/src/customDBHeaders.js
@@ -1,0 +1,16 @@
+// Add a header to customDBHeaders if it's missing
+export async function addCustomDBHeader(headerName) {
+  let customDBHeaders = await messenger.LegacyPrefs.getPref("mailnews.customDBHeaders", "");
+  if (!customDBHeaders.toLowerCase().includes(headerName.toLowerCase())) {
+    customDBHeaders += " " + headerName;
+    await messenger.LegacyPrefs.setPref("mailnews.customDBHeaders", customDBHeaders);
+  }
+}
+
+// Remove a header from customDBHeaders if it's present
+export async function removeCustomDBHeader(headerName) {
+  let customDBHeaders = await messenger.LegacyPrefs.getPref("mailnews.customDBHeaders", "");
+  let regex = new RegExp(` *${headerName}`, "i");
+  customDBHeaders = customDBHeaders.replace(regex, "");
+  await messenger.LegacyPrefs.setPref("mailnews.customDBHeaders", customDBHeaders);
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,12 +29,12 @@
         "script": "api/ex_runtime/parent.js"
       }
     },
-    "HeaderColumns": {
-      "schema": "api/header-columns-api/schema.json",
+    "OriginalToColumn": {
+      "schema": "api/OriginalToColumn/schema.json",
       "parent": {
         "scopes": ["addon_parent"],
-        "paths": [["HeaderColumns"]],
-        "script": "api/header-columns-api/implementation.js"
+        "paths": [["OriginalToColumn"]],
+        "script": "api/OriginalToColumn/implementation.js"
       }
     }
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,14 +2,14 @@
   "manifest_version": 2,
   "name": "X-Original-To Column",
   "description": "Adds a column for the X-Original-To header to message list panel",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "author": "Peter Fabinski",
   "homepage_url": "https://github.com/peterfab9845/original-to-column",
   "applications": {
     "gecko": {
       "id": "original-to-column@peterfab.com",
-      "strict_min_version": "68.0a1",
-      "strict_max_version": "102.*"
+      "strict_min_version": "115.0",
+      "strict_max_version": "128.*"
     }
   },
   "experiment_apis": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,6 +39,7 @@
     }
   },
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js"],
+    "type": "module"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "original-to-column@peterfab.com",
-      "strict_min_version": "115.0",
+      "strict_min_version": "115.10",
       "strict_max_version": "128.*"
     }
   },


### PR DESCRIPTION
This PR uses the new custom column support for add-ons. It still uses an Experiment, because the new method has not yet been made available through a WebExtension API.

The add-on currently uses a generic header-columns-API which covers a lot of special cases. This PR replaces that API by a very simple minimal Experiment, which covers just the use case for the original-to-column add-on. 